### PR TITLE
Fix form-control layout

### DIFF
--- a/dist/select2-bootstrap4.css
+++ b/dist/select2-bootstrap4.css
@@ -59,8 +59,10 @@
     .select2-container--bootstrap4 .select2-selection--multiple .select2-selection__choice__remove:hover {
       color: #343a40; }
 
-.select2-container *:focus {
-  outline: 0; }
+.select2-container {
+  display: block; }
+  .select2-container *:focus {
+    outline: 0; }
 
 .select2-container--bootstrap4 .select2-selection {
   border: 1px solid #ced4da;

--- a/src/layout.scss
+++ b/src/layout.scss
@@ -6,6 +6,8 @@
 
 // basic
 .select2-container {
+    display: block;
+
     *:focus {
         outline: 0;
     }


### PR DESCRIPTION
The input field does not use the full size of the fieldset, with this change it fits the column fully.
Also the select2 option "width" must be set to "style", otherwise the calculation makes it go beyond the fieldset.