### PR TITLE
Scope CSS option class to fix vertical scrolling in optgroups

### DIFF
--- a/src/layout.scss
+++ b/src/layout.scss
@@ -70,7 +70,7 @@
     }
 
     // fixes vertical overflow
-    .select2-results__options {
+    .select2-results > .select2-results__options {
         max-height: 15em;
         overflow-y: auto;
     }


### PR DESCRIPTION
Mirrors implementation of Select2's built-in themes. Properly scopes the `.select2-results__options` class to be a direct descendant of `.select2-results`.