### PR TITLE
Enable to use input group

### DIFF
--- a/dist/select2-bootstrap4.css
+++ b/dist/select2-bootstrap4.css
@@ -64,6 +64,15 @@
   .select2-container *:focus {
     outline: 0; }
 
+.input-group .select2-container--bootstrap4 {
+  -webkit-box-flex: 1;
+      -ms-flex-positive: 1;
+          flex-grow: 1; }
+
+.input-group-prepend ~ .select2-container--bootstrap4 .select2-selection {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0; }
+
 .select2-container--bootstrap4 .select2-selection {
   border: 1px solid #ced4da;
   border-radius: 0.25rem;

--- a/docs/index.html
+++ b/docs/index.html
@@ -60,6 +60,20 @@
         </optgroup>
       </select>
     </div>
+    <div class="form-group">
+      <label>Example of input-group</label>
+      <div class="input-group">
+        <div class="input-group-prepend">
+          <span class="input-group-text">Prepend</span>
+        </div>
+        <select placeholder="Choose on thing">
+          <option></option>
+          <option>1</option>
+          <option>2</option>
+          <option>3</option>
+        </select>
+      </div>
+    </div>
   </form>
 </div>
 

--- a/src/layout.scss
+++ b/src/layout.scss
@@ -13,6 +13,20 @@
     }
 }
 
+// input-group
+.input-group .select2-container--bootstrap4 {
+    flex-grow: 1;
+}
+.input-group-prepend ~ .select2-container--bootstrap4 .select2-selection {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+}
+// waiting css4
+//.select2-container--bootstrap4:has(~ .input-group-append) .select2-selection {
+//    border-top-right-radius: 0;
+//    border-bottom-right-radius: 0;
+//}
+
 .select2-container--bootstrap4 {
 
     // input box


### PR DESCRIPTION
closes #1

![image](https://user-images.githubusercontent.com/4360663/56705863-b34fb980-674d-11e9-87df-070446e84318.png)

> **NOTE**
> I cannot remove right side border-radius only when `input-group-append` exists. I'm waiting `:has()` selector which may be come with css4.
> https://github.com/ttskch/select2-bootstrap4-theme/pull/14/files#diff-9aca7faeed338270dde16ab067f4b168R25