### PR TITLE
Get the primary theme colour properly

### DIFF
--- a/src/layout.scss
+++ b/src/layout.scss
@@ -102,7 +102,7 @@
   // mouse hovered item
   .select2-results__option--highlighted,
   .select2-results__option--highlighted.select2-results__option[aria-selected=true] {
-    background-color: $primary;
+    background-color: theme-color("primary");
     color: $light;
   }
 


### PR DESCRIPTION
Using the bootstrap function to get the theme colour means that the source can be used by people who have overridden the primary theme colour by setting it in `$theme-colours` as per bootstrap docs

https://getbootstrap.com/docs/4.5/getting-started/theming/#modify-map

Fixes #46