### PR TITLE
Update the disabled multi-select SCSS to hide the remove

### DIFF
--- a/src/_multiple.scss
+++ b/src/_multiple.scss
@@ -56,4 +56,22 @@
       right: 0.7em;
     }
   }
+  &.select2-container--disabled
+  {
+    .select2-selection--multiple
+    {
+      .select2-selection__choice
+      {
+        padding: 0 5px;
+        .select2-selection__choice__remove
+        {
+          display: none;
+        }
+      }
+      .select2-search__field
+      {
+        display: none;
+      }
+    }
+  }
 }


### PR DESCRIPTION
In select2 by default the X is removed from option pills in the multiselect.
With this theme enabled that behaviour is overriden and shows the x along with it having the hover state.
<img width="590" alt="Screen Shot 2020-07-20 at 4 20 38 PM" src="https://user-images.githubusercontent.com/8726005/87995672-fd386400-caa4-11ea-9258-56d935286145.png">

This change suppresses the x on the option pills when disabled.
<img width="924" alt="Screen Shot 2020-07-20 at 11 11 11 AM" src="https://user-images.githubusercontent.com/8726005/87995703-13462480-caa5-11ea-8211-620dff5eb517.png">

Also suppresses the input field to avoid the case when there's enough options to fill the line leaving a seemingly empty line after the options.
<img width="647" alt="Screen Shot 2020-07-20 at 4 22 17 PM" src="https://user-images.githubusercontent.com/8726005/87995748-353fa700-caa5-11ea-95c8-94aba16c17fc.png">
So now that empty space doesn't occur;
<img width="645" alt="Screen Shot 2020-07-20 at 4 22 43 PM" src="https://user-images.githubusercontent.com/8726005/87995788-4d172b00-caa5-11ea-9ef4-2d352b941a49.png">
