### PR TITLE
Fix search field background color.

### DIFF
--- a/src/_layout.scss
+++ b/src/_layout.scss
@@ -92,6 +92,17 @@
   .select2-search {
     width: 100%;
   }
+  
+  // fixes search field background;
+  .select2-search--inline {
+    .select2-search__field {
+      background: transparent;
+      border: none;
+      outline: 0;
+      box-shadow: none;
+      -webkit-appearance: textfield;
+    }
+  }
 
   // dropdown
   .select2-dropdown {


### PR DESCRIPTION
Fix select2-search__field background color by changing to transparent like default and classic themes.

Currently when the Bootstrap's $input-bg variable isn't white, the search field still white and looks like this:
![image](https://user-images.githubusercontent.com/29079104/131568985-fc71ed18-db88-44ef-b4a8-cdec42af24cd.png)
